### PR TITLE
Related items comparison modal now dynamically renders

### DIFF
--- a/client/src/components/RelatedItems/CarouselList.jsx
+++ b/client/src/components/RelatedItems/CarouselList.jsx
@@ -26,9 +26,9 @@ function CarouselList() {
         {relatedIndex !== related.length - 5 && <FaChevronRight className={itemStyles['right-arrow']} onClick={nextSlide} />}
       </div>
       <div>
-        <FaChevronLeft />
+        {/* <FaChevronLeft />
         <OutfitList />
-        <FaChevronRight />
+        <FaChevronRight /> */}
       </div>
     </div>
   );

--- a/client/src/components/RelatedItems/CarouselList.jsx
+++ b/client/src/components/RelatedItems/CarouselList.jsx
@@ -3,15 +3,17 @@ import { FaChevronLeft, FaChevronRight } from 'react-icons/fa';
 import { useSelector, useDispatch } from 'react-redux';
 import ItemsList from './ItemsList';
 import OutfitList from './OutfitList';
+import itemStyles from './Items.module.css';
 import { newRelatedCarouselIndex } from '../../features/related/relatedSlice';
 
-function CarouselList({ itemStyles }) {
+function CarouselList() {
   let { relatedIndex, related } = useSelector((state) => state.related);
   const dispatch = useDispatch();
 
   function nextSlide() {
     dispatch(newRelatedCarouselIndex(relatedIndex === related.length - 1 ? 0 : relatedIndex + 1));
   }
+
   function prevSlide() {
     dispatch(newRelatedCarouselIndex(relatedIndex === 0 ? related.length - 1 : relatedIndex - 1));
   }
@@ -20,13 +22,13 @@ function CarouselList({ itemStyles }) {
     <div>
       <div className={itemStyles['items-list-container']}>
         {relatedIndex !== 0 && <FaChevronLeft className={itemStyles['left-arrow']} onClick={prevSlide} />}
-        <ItemsList itemStyles={itemStyles} relatedIndex={relatedIndex} />
+        <ItemsList relatedIndex={relatedIndex} />
         {relatedIndex !== related.length - 5 && <FaChevronRight className={itemStyles['right-arrow']} onClick={nextSlide} />}
       </div>
       <div>
-        {/* <FaChevronLeft />
+        <FaChevronLeft />
         <OutfitList />
-        <FaChevronRight /> */}
+        <FaChevronRight />
       </div>
     </div>
   );

--- a/client/src/components/RelatedItems/CarouselList.jsx
+++ b/client/src/components/RelatedItems/CarouselList.jsx
@@ -5,16 +5,16 @@ import ItemsList from './ItemsList';
 import OutfitList from './OutfitList';
 import { newRelatedCarouselIndex } from '../../features/related/relatedSlice';
 
-const CarouselList = function ({ itemStyles }) {
+function CarouselList({ itemStyles }) {
   let { relatedIndex, related } = useSelector((state) => state.related);
   const dispatch = useDispatch();
 
-  const nextSlide = function () {
+  function nextSlide() {
     dispatch(newRelatedCarouselIndex(relatedIndex === related.length - 1 ? 0 : relatedIndex + 1));
-  };
-  const prevSlide = function () {
+  }
+  function prevSlide() {
     dispatch(newRelatedCarouselIndex(relatedIndex === 0 ? related.length - 1 : relatedIndex - 1));
-  };
+  }
 
   return (
     <div>
@@ -30,7 +30,7 @@ const CarouselList = function ({ itemStyles }) {
       </div>
     </div>
   );
-};
+}
 
 export default CarouselList;
 

--- a/client/src/components/RelatedItems/ComparisonModal.jsx
+++ b/client/src/components/RelatedItems/ComparisonModal.jsx
@@ -11,40 +11,37 @@ function ComparisonModal({ sampleChar }) {
   const dispatch = useDispatch();
   const [modal] = useState(data.sampleModal);
 
+  let mappedData = [];
+
   function comparisonData() {
-    const combinedData = {};
+    const combinedData = [];
     const relatedProductDetails = relatedProductFeatures;
     const currentProductDetails = details.features;
     relatedProductDetails.forEach((char) => {
       const description = char.value ? `${char.feature}: ${char.value}` : char.feature;
-      combinedData[description] = { related: true, current: false };
+      combinedData.push({ value: description, related: true, current: false });
     });
     currentProductDetails.forEach((char) => {
       const description = char.value ? `${char.feature}: ${char.value}` : char.feature;
-      if (combinedData[description]) {
-        combinedData[description].current = true;
-      } else {
-        combinedData[description] = { related: false, current: true };
-      }
+      let flag = false;
+      combinedData.forEach((el) => {
+        if (el.value === description) {
+          el.current = true;
+          flag = true;
+        }
+      });
+      if (!flag) { combinedData.push({ value: description, related: false, current: true }); }
     });
-    dispatch(newCombinedProductFeatures(combinedData));
-    const mappedData = Object.keys(combinedProductFeatures).map(
-      (key) => ({
-        value: key,
-        related: combinedProductFeatures[key].related,
-        current: combinedProductFeatures[key].current,
-      }),
-    );
-    dispatch(newCombinedProductFeatures(mappedData));
-    // console.log('combinedProductFeaturesOutside: ', mappedData);
+    console.log('combinedData: ', combinedData);
+    // dispatch(newCombinedProductFeatures(combinedData));
   }
 
   function renderComparison(char, index) {
     return (
       <tr key={index}>
-        <td>{char.currYes && <FaToolbox />}</td>
+        <td>{char.current && <FaToolbox />}</td>
         <td>{char.value}</td>
-        <td>{char.relYes && <FaToolbox />}</td>
+        <td>{char.related && <FaToolbox />}</td>
       </tr>
     );
   }
@@ -61,7 +58,7 @@ function ComparisonModal({ sampleChar }) {
           </tr>
         </thead>
         <tbody>
-          {modal.map((char, index) => renderComparison(char, index))}
+          {combinedProductFeatures.map((char, index) => renderComparison(char, index))}
         </tbody>
       </table>
     )

--- a/client/src/components/RelatedItems/ComparisonModal.jsx
+++ b/client/src/components/RelatedItems/ComparisonModal.jsx
@@ -3,9 +3,10 @@ import { FaToolbox } from 'react-icons/fa';
 import data from './sampleData';
 import itemStyles from './Items.module.css';
 import { useSelector, useDispatch } from 'react-redux';
+import { newCombinedProductFeatures } from '../../features/related/relatedSlice';
 
 function ComparisonModal({ sampleChar }) {
-  let { modalOpen, relatedProductFeatures } = useSelector((state) => state.related);
+  let { modalOpen, relatedProductFeatures, combinedProductFeatures } = useSelector((state) => state.related);
   let { details } = useSelector((state) => state.products);
   const dispatch = useDispatch();
   const [modal] = useState(data.sampleModal);
@@ -14,7 +15,7 @@ function ComparisonModal({ sampleChar }) {
     const combinedData = {};
     const relatedProductDetails = relatedProductFeatures;
     const currentProductDetails = details.features;
-
+    function generateData() {
     relatedProductDetails.forEach((char) => {
       const description = char.value ? `${char.feature}: ${char.value}` : char.feature;
       combinedData[description] = { related: true, current: false };
@@ -27,10 +28,11 @@ function ComparisonModal({ sampleChar }) {
         combinedData[description] = { related: false, current: true };
       }
     });
-
-    console.log('combinedData: ', combinedData);
-    console.log('relatedProductFeatures: ', relatedProductFeatures);
-    console.log('details.features: ', details.features);
+    dispatch(newCombinedProductFeatures(combinedData));
+    console.log('combinedProductFeatures: ', combinedProductFeatures);
+    // console.log('combinedData: ', combinedData);
+    // console.log('relatedProductFeatures: ', relatedProductFeatures);
+    // console.log('details.features: ', details.features);
   }
 
   function renderComparison(char, index) {

--- a/client/src/components/RelatedItems/ComparisonModal.jsx
+++ b/client/src/components/RelatedItems/ComparisonModal.jsx
@@ -23,17 +23,17 @@ function ComparisonModal({ sampleChar }) {
     });
     currentProductDetails.forEach((char) => {
       const description = char.value ? `${char.feature}: ${char.value}` : char.feature;
-      let flag = false;
+      let hasCharacteristic = false;
       combinedData.forEach((el) => {
         if (el.value === description) {
           el.current = true;
-          flag = true;
+          hasCharacteristic = true;
         }
       });
-      if (!flag) { combinedData.push({ value: description, related: false, current: true }); }
+      if (!hasCharacteristic) { combinedData.push({ value: description, related: false, current: true }); }
     });
-    console.log('combinedData: ', combinedData);
-    // dispatch(newCombinedProductFeatures(combinedData));
+    // console.log('combinedData: ', combinedData);
+    dispatch(newCombinedProductFeatures(combinedData));
   }
 
   function renderComparison(char, index) {

--- a/client/src/components/RelatedItems/ComparisonModal.jsx
+++ b/client/src/components/RelatedItems/ComparisonModal.jsx
@@ -3,7 +3,7 @@ import { FaToolbox } from 'react-icons/fa';
 import data from './sampleData';
 import { useSelector, useDispatch } from 'react-redux';
 
-const ComparisonModal = function ({ itemStyles, sampleChar }) {
+function ComparisonModal({ itemStyles, sampleChar }) {
   let { modalOpen } = useSelector((state) => state.related);
   const dispatch = useDispatch();
   const [modal] = useState(data.sampleModal);
@@ -33,6 +33,6 @@ const ComparisonModal = function ({ itemStyles, sampleChar }) {
       </tbody>
     </table>
   );
-};
+}
 
 export default ComparisonModal;

--- a/client/src/components/RelatedItems/ComparisonModal.jsx
+++ b/client/src/components/RelatedItems/ComparisonModal.jsx
@@ -28,10 +28,15 @@ function ComparisonModal({ sampleChar }) {
       }
     });
     dispatch(newCombinedProductFeatures(combinedData));
-    console.log('combinedProductFeatures: ', combinedProductFeatures);
-    // console.log('combinedData: ', combinedData);
-    // console.log('relatedProductFeatures: ', relatedProductFeatures);
-    // console.log('details.features: ', details.features);
+    const mappedData = Object.keys(combinedProductFeatures).map(
+      (key) => ({
+        value: key,
+        related: combinedProductFeatures[key].related,
+        current: combinedProductFeatures[key].current,
+      }),
+    );
+    dispatch(newCombinedProductFeatures(mappedData));
+    // console.log('combinedProductFeaturesOutside: ', mappedData);
   }
 
   function renderComparison(char, index) {

--- a/client/src/components/RelatedItems/ComparisonModal.jsx
+++ b/client/src/components/RelatedItems/ComparisonModal.jsx
@@ -6,10 +6,34 @@ import { useSelector, useDispatch } from 'react-redux';
 
 function ComparisonModal({ sampleChar }) {
   let { modalOpen, relatedProductFeatures } = useSelector((state) => state.related);
+  let { details } = useSelector((state) => state.products);
   const dispatch = useDispatch();
   const [modal] = useState(data.sampleModal);
 
-  const renderComparison = function (char, index) {
+  function comparisonData() {
+    const combinedData = {};
+    const relatedProductDetails = relatedProductFeatures;
+    const currentProductDetails = details.features;
+
+    relatedProductDetails.forEach((char) => {
+      const description = char.value ? `${char.feature}: ${char.value}` : char.feature;
+      combinedData[description] = { related: true, current: false };
+    });
+    currentProductDetails.forEach((char) => {
+      const description = char.value ? `${char.feature}: ${char.value}` : char.feature;
+      if (combinedData[description]) {
+        combinedData[description].current = true;
+      } else {
+        combinedData[description] = { related: false, current: true };
+      }
+    });
+
+    console.log('combinedData: ', combinedData);
+    console.log('relatedProductFeatures: ', relatedProductFeatures);
+    console.log('details.features: ', details.features);
+  }
+
+  function renderComparison(char, index) {
     return (
       <tr key={index}>
         <td>{char.currYes && <FaToolbox />}</td>
@@ -17,24 +41,25 @@ function ComparisonModal({ sampleChar }) {
         <td>{char.relYes && <FaToolbox />}</td>
       </tr>
     );
-  };
-
-  console.log('relatedProductFeatures: ', relatedProductFeatures);
+  }
 
   return (
-    <table>
-      <caption>Comparing</caption>
-      <thead>
-        <tr>
-          <th>Current Product</th>
-          <th>Characteristic</th>
-          <th>Related Product</th>
-        </tr>
-      </thead>
-      <tbody>
-        {modal.map((char, index) => renderComparison(char, index))}
-      </tbody>
-    </table>
+    { modalOpen } ? (
+      <table>
+        <caption onClick={comparisonData}>Comparing</caption>
+        <thead>
+          <tr>
+            <th>Current Product</th>
+            <th>Characteristic</th>
+            <th>Related Product</th>
+          </tr>
+        </thead>
+        <tbody>
+          {modal.map((char, index) => renderComparison(char, index))}
+        </tbody>
+      </table>
+    )
+      : null
   );
 }
 

--- a/client/src/components/RelatedItems/ComparisonModal.jsx
+++ b/client/src/components/RelatedItems/ComparisonModal.jsx
@@ -15,7 +15,6 @@ function ComparisonModal({ sampleChar }) {
     const combinedData = {};
     const relatedProductDetails = relatedProductFeatures;
     const currentProductDetails = details.features;
-    function generateData() {
     relatedProductDetails.forEach((char) => {
       const description = char.value ? `${char.feature}: ${char.value}` : char.feature;
       combinedData[description] = { related: true, current: false };

--- a/client/src/components/RelatedItems/ComparisonModal.jsx
+++ b/client/src/components/RelatedItems/ComparisonModal.jsx
@@ -1,10 +1,11 @@
 import React, { useState } from 'react';
 import { FaToolbox } from 'react-icons/fa';
 import data from './sampleData';
+import itemStyles from './Items.module.css';
 import { useSelector, useDispatch } from 'react-redux';
 
-function ComparisonModal({ itemStyles, sampleChar }) {
-  let { modalOpen } = useSelector((state) => state.related);
+function ComparisonModal({ sampleChar }) {
+  let { modalOpen, relatedProductFeatures } = useSelector((state) => state.related);
   const dispatch = useDispatch();
   const [modal] = useState(data.sampleModal);
 
@@ -17,6 +18,8 @@ function ComparisonModal({ itemStyles, sampleChar }) {
       </tr>
     );
   };
+
+  console.log('relatedProductFeatures: ', relatedProductFeatures);
 
   return (
     <table>

--- a/client/src/components/RelatedItems/FormatCard.jsx
+++ b/client/src/components/RelatedItems/FormatCard.jsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import { useSelector, useDispatch } from 'react-redux';
+import itemStyles from './Items.module.css';
 
-function FormatCard({ name, image, price, category, stars, itemStyles }) {
+function FormatCard({ name, image, price, category, stars }) {
   return (
     <div className={itemStyles['items-card']}>
-      <img className={itemStyles['items-card-img']} src={image} />
+      <img className={itemStyles['items-card-img']} src={image} alt="" />
       <div>{stars}</div>
       <p className={itemStyles['product-category']}>{category}</p>
       <h6 className={itemStyles['product-name']}>{name}</h6>

--- a/client/src/components/RelatedItems/FormatCard.jsx
+++ b/client/src/components/RelatedItems/FormatCard.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 
-const FormatCard = function ({ name, image, price, category, stars, itemStyles }) {
+function FormatCard({ name, image, price, category, stars, itemStyles }) {
   return (
     <div className={itemStyles['items-card']}>
       <img className={itemStyles['items-card-img']} src={image} />

--- a/client/src/components/RelatedItems/GenerateComparisonData.jsx
+++ b/client/src/components/RelatedItems/GenerateComparisonData.jsx
@@ -1,31 +1,31 @@
-import { useSelector, useDispatch } from 'react-redux';
-import { newCombinedProductFeatures } from '../../features/related/relatedSlice';
+// import { useSelector, useDispatch } from 'react-redux';
+// import { newCombinedProductFeatures } from '../../features/related/relatedSlice';
 
-function GenerateComparisonData() {
-  let { relatedProductFeatures } = useSelector((state) => state.related);
-  let { details } = useSelector((state) => state.products);
-  const dispatch = useDispatch();
+// function GenerateComparisonData() {
+//   let { relatedProductFeatures } = useSelector((state) => state.related);
+//   let { details } = useSelector((state) => state.products);
+//   const dispatch = useDispatch();
 
-  const combinedData = {};
-  const relatedProductDetails = relatedProductFeatures;
-  const currentProductDetails = details.features;
+//   const combinedData = {};
+//   const relatedProductDetails = relatedProductFeatures;
+//   const currentProductDetails = details.features;
 
-  relatedProductDetails.forEach((char) => {
-    const description = char.value ? `${char.feature}: ${char.value}` : char.feature;
-    combinedData[description] = { related: true, current: false };
-  });
-  currentProductDetails.forEach((char) => {
-    const description = char.value ? `${char.feature}: ${char.value}` : char.feature;
-    if (combinedData[description]) {
-      combinedData[description].current = true;
-    } else {
-      combinedData[description] = { related: false, current: true };
-    }
-  });
-  dispatch(newCombinedProductFeatures(combinedData));
-  console.log('combinedData: ', combinedData);
-  console.log('relatedProductFeatures: ', relatedProductFeatures);
-  console.log('details.features: ', details.features);
-}
+//   relatedProductDetails.forEach((char) => {
+//     const description = char.value ? `${char.feature}: ${char.value}` : char.feature;
+//     combinedData[description] = { related: true, current: false };
+//   });
+//   currentProductDetails.forEach((char) => {
+//     const description = char.value ? `${char.feature}: ${char.value}` : char.feature;
+//     if (combinedData[description]) {
+//       combinedData[description].current = true;
+//     } else {
+//       combinedData[description] = { related: false, current: true };
+//     }
+//   });
+//   dispatch(newCombinedProductFeatures(combinedData));
+//   console.log('combinedData: ', combinedData);
+//   console.log('relatedProductFeatures: ', relatedProductFeatures);
+//   console.log('details.features: ', details.features);
+// }
 
-export default GenerateComparisonData;
+// export default GenerateComparisonData;

--- a/client/src/components/RelatedItems/GenerateComparisonData.jsx
+++ b/client/src/components/RelatedItems/GenerateComparisonData.jsx
@@ -1,0 +1,31 @@
+import { useSelector, useDispatch } from 'react-redux';
+import { newCombinedProductFeatures } from '../../features/related/relatedSlice';
+
+function GenerateComparisonData() {
+  let { relatedProductFeatures } = useSelector((state) => state.related);
+  let { details } = useSelector((state) => state.products);
+  const dispatch = useDispatch();
+
+  const combinedData = {};
+  const relatedProductDetails = relatedProductFeatures;
+  const currentProductDetails = details.features;
+
+  relatedProductDetails.forEach((char) => {
+    const description = char.value ? `${char.feature}: ${char.value}` : char.feature;
+    combinedData[description] = { related: true, current: false };
+  });
+  currentProductDetails.forEach((char) => {
+    const description = char.value ? `${char.feature}: ${char.value}` : char.feature;
+    if (combinedData[description]) {
+      combinedData[description].current = true;
+    } else {
+      combinedData[description] = { related: false, current: true };
+    }
+  });
+  dispatch(newCombinedProductFeatures(combinedData));
+  console.log('combinedData: ', combinedData);
+  console.log('relatedProductFeatures: ', relatedProductFeatures);
+  console.log('details.features: ', details.features);
+}
+
+export default GenerateComparisonData;

--- a/client/src/components/RelatedItems/ItemsList.jsx
+++ b/client/src/components/RelatedItems/ItemsList.jsx
@@ -47,7 +47,7 @@ const ItemsList = function ({ relatedIndex, itemStyles }) {
       <div key={index} onClick={(e) => handleModalClick(e, item)}>
         {relatedIndex <= index && (
           <FormatCard
-            stars={<QuarterStarsAverageRating rating={item.ratings.ratings} />}
+            stars={<QuarterStarsAverageRating productRating={item.ratings.ratings} />}
             name={item.details.name}
             category={item.details.category}
             image={findImage(item)}

--- a/client/src/components/RelatedItems/ItemsList.jsx
+++ b/client/src/components/RelatedItems/ItemsList.jsx
@@ -6,7 +6,7 @@ import { useParams } from "react-router-dom";
 import { useDispatch } from 'react-redux';
 import { newModalState, newCurrentRelatedProduct } from '../../features/related/relatedSlice';
 
-const ItemsList = function ({ relatedIndex, itemStyles }) {
+function ItemsList({ relatedIndex, itemStyles }) {
   const dispatch = useDispatch();
   const params = useParams();
   const {
@@ -16,7 +16,7 @@ const ItemsList = function ({ relatedIndex, itemStyles }) {
     refetchOnMountOrArgChange: true,
   });
 
-  const findImage = function(item) {
+  function findImage(item) {
     for (let i = 0; i < item.photos.results.length; i++) {
       const style = item.photos.results[i];
       for (let j = 0; j < style.photos.length; j++) {
@@ -36,13 +36,13 @@ const ItemsList = function ({ relatedIndex, itemStyles }) {
   //   };
   // };
 
-  const handleModalClick = function(e, item) {
+  function handleModalClick(e, item) {
     e.preventDefault();
     dispatch(newModalState());
     dispatch(newCurrentRelatedProduct(item.details.features));
-  };
+  }
 
-  const renderList = function (item, index) {
+  function renderList(item, index) {
     return (
       <div key={index} onClick={(e) => handleModalClick(e, item)}>
         {relatedIndex <= index && (
@@ -57,7 +57,7 @@ const ItemsList = function ({ relatedIndex, itemStyles }) {
         )}
       </div>
     );
-  };
+  }
 
   if (isFetching) {
     return <div>loading...</div>;
@@ -71,6 +71,6 @@ const ItemsList = function ({ relatedIndex, itemStyles }) {
       </div>
     </div>
   );
-};
+}
 
 export default ItemsList;

--- a/client/src/components/RelatedItems/ItemsList.jsx
+++ b/client/src/components/RelatedItems/ItemsList.jsx
@@ -4,9 +4,10 @@ import QuarterStarsAverageRating from '../ReviewsRatings/QuarterStarsAverageRati
 import { useGetRelatedProductInfoQuery } from '../../features/api/apiSlice';
 import { useParams } from "react-router-dom";
 import { useDispatch } from 'react-redux';
-import { newModalState, newCurrentRelatedProduct } from '../../features/related/relatedSlice';
+import { newModalState, newRelatedProductFeatures } from '../../features/related/relatedSlice';
+import itemStyles from './Items.module.css';
 
-function ItemsList({ relatedIndex, itemStyles }) {
+function ItemsList({ relatedIndex }) {
   const dispatch = useDispatch();
   const params = useParams();
   const {
@@ -26,7 +27,7 @@ function ItemsList({ relatedIndex, itemStyles }) {
         }
       }
     }
-  };
+  }
 
   // ATTEMPTED REFACTOR, DOES NOT WORK
   // const findImage = function (item) {
@@ -39,7 +40,7 @@ function ItemsList({ relatedIndex, itemStyles }) {
   function handleModalClick(e, item) {
     e.preventDefault();
     dispatch(newModalState());
-    dispatch(newCurrentRelatedProduct(item.details.features));
+    dispatch(newRelatedProductFeatures(item.details.features));
   }
 
   function renderList(item, index) {

--- a/client/src/components/RelatedItems/OutfitList.jsx
+++ b/client/src/components/RelatedItems/OutfitList.jsx
@@ -4,7 +4,7 @@ import { useParams } from "react-router-dom";
 import { useSelector, useDispatch } from 'react-redux';
 import { useGetRelatedProductInfoQuery } from '../../features/api/apiSlice';
 
-const OutfitList = function ({ itemStyles }) {
+function OutfitList({ itemStyles }) {
   const params = useParams();
   const {
     data: relatedProducts,
@@ -16,7 +16,7 @@ const OutfitList = function ({ itemStyles }) {
   let { selectedStyle, styles } = useSelector((state) => state.products);
   const dispatch = useDispatch();
 
-  const renderList = function (item, index) {
+  function renderList(item, index) {
     return (
       <FormatCard
         key={index}
@@ -27,7 +27,7 @@ const OutfitList = function ({ itemStyles }) {
         itemStyles={itemStyles}
       />
     );
-  };
+  }
 
   if (isFetching) {
     return <div>loading...</div>;
@@ -41,6 +41,6 @@ const OutfitList = function ({ itemStyles }) {
       </div>
     </div>
   );
-};
+}
 
 export default OutfitList;

--- a/client/src/components/RelatedItems/OutfitList.jsx
+++ b/client/src/components/RelatedItems/OutfitList.jsx
@@ -1,10 +1,11 @@
 import React, { useState } from 'react';
-import FormatCard from './FormatCard';
 import { useParams } from "react-router-dom";
 import { useSelector, useDispatch } from 'react-redux';
 import { useGetRelatedProductInfoQuery } from '../../features/api/apiSlice';
+import FormatCard from './FormatCard';
+import itemStyles from './Items.module.css';
 
-function OutfitList({ itemStyles }) {
+function OutfitList() {
   const params = useParams();
   const {
     data: relatedProducts,
@@ -24,7 +25,6 @@ function OutfitList({ itemStyles }) {
         category={item.details.category}
         image={item.photos.results[0].photos.url}
         price={item.details.default_price}
-        itemStyles={itemStyles}
       />
     );
   }

--- a/client/src/components/RelatedItems/OutfitList.jsx
+++ b/client/src/components/RelatedItems/OutfitList.jsx
@@ -14,7 +14,7 @@ function OutfitList() {
     refetchOnMountOrArgChange: true,
   });
 
-  let { selectedStyle, styles } = useSelector((state) => state.products);
+  let { selectedStyle, styles, details } = useSelector((state) => state.products);
   const dispatch = useDispatch();
 
   function renderList(item, index) {

--- a/client/src/components/RelatedItems/RelatedItems.jsx
+++ b/client/src/components/RelatedItems/RelatedItems.jsx
@@ -1,19 +1,15 @@
 import React from 'react';
-import ItemsList from './ItemsList';
 import itemStyles from './Items.module.css';
-import OutfitList from './OutfitList';
 import CarouselList from './CarouselList';
 import ComparisonModal from './ComparisonModal';
 
-const RelatedItems = function () {
+function RelatedItems() {
   return (
     <div>
       <CarouselList itemStyles={itemStyles} />
-      {/* <ItemsList itemStyles={itemStyles} />
-      <OutfitList itemStyles={itemStyles} /> */}
       <ComparisonModal itemStyles={itemStyles} />
     </div>
   );
-};
+}
 
 export default RelatedItems;

--- a/client/src/components/ReviewsRatings/ReviewTile.jsx
+++ b/client/src/components/ReviewsRatings/ReviewTile.jsx
@@ -12,7 +12,7 @@ function ReviewTile({ index }) {
   const [helpful, setHelpful] = useState('No');
   // send a post request with the helpful state to the API when helpful is 'yes'
   const { reviews } = useSelector((state) => state.reviews);
-  console.log("reviews data", reviews)
+  // console.log("reviews data", reviews)
   const [modalImage, setModalImage] = useState(false);
   const [photoState, setPhotoState] = useState('');
   const toggleModalImage = (inputBool) => (

--- a/client/src/features/api/apiSlice.js
+++ b/client/src/features/api/apiSlice.js
@@ -56,7 +56,7 @@ export const api = createApi({
           ratingsDetails.data ? relatedItem.ratings = ratingsDetails.data : relatedItem.ratingsError = ratingsDetails.error;
           const allPhotos = await fetchWithBQ(`/products/${item}/styles`);
           allPhotos.data ? relatedItem.photos = allPhotos.data : relatedItem.photoError = allPhotos.error;
-          return relatedItem;   
+          return relatedItem;
         }));
         return { data: allItems };
       },

--- a/client/src/features/related/relatedSlice.js
+++ b/client/src/features/related/relatedSlice.js
@@ -8,6 +8,7 @@ const initialState = {
   outfitLength: 0,
   modalOpen: false,
   relatedProductFeatures: {},
+  combinedProductFeatures: {},
 };
 
 function moveRelatedCarousel(state = initialState, action) {
@@ -23,6 +24,9 @@ function toggleModal(state = initialState, action) {
 function setRelatedProductFeatures(state = initialState, action) {
   return { ...state, relatedProductFeatures: action.payload };
 }
+function setCombinedProductFeatures(state = initialState, action) {
+  return { ...state, combinedProductFeatures: action.payload };
+}
 
 const relatedSlice = createSlice({
   name: 'related',
@@ -33,6 +37,7 @@ const relatedSlice = createSlice({
     newOutfitCarouselIndex: moveOutfitCarousel,
     newModalState: toggleModal,
     newRelatedProductFeatures: setRelatedProductFeatures,
+    newCombinedProductFeatures: setCombinedProductFeatures,
   },
   extraReducers: (builder) => {
     builder
@@ -48,6 +53,7 @@ export const {
   newOutfitCarouselIndex,
   newModalState,
   newRelatedProductFeatures,
+  newCombinedProductFeatures,
 } = relatedSlice.actions;
 
 export default relatedSlice.reducer;

--- a/client/src/features/related/relatedSlice.js
+++ b/client/src/features/related/relatedSlice.js
@@ -8,7 +8,7 @@ const initialState = {
   outfitLength: 0,
   modalOpen: false,
   relatedProductFeatures: {},
-  combinedProductFeatures: {},
+  combinedProductFeatures: [],
 };
 
 function moveRelatedCarousel(state = initialState, action) {

--- a/client/src/features/related/relatedSlice.js
+++ b/client/src/features/related/relatedSlice.js
@@ -7,7 +7,7 @@ const initialState = {
   outfitIndex: 0,
   outfitLength: 0,
   modalOpen: false,
-  currentRelatedProduct: {},
+  relatedProductFeatures: {},
 };
 
 function moveRelatedCarousel(state = initialState, action) {
@@ -20,8 +20,8 @@ function toggleModal(state = initialState, action) {
   const toggle = (input) => !input;
   state.modalOpen = toggle(state.modalOpen);
 }
-function setCurrentRelatedProduct(state = initialState, action) {
-  return { ...state, currentRelatedProduct: action.payload };
+function setRelatedProductFeatures(state = initialState, action) {
+  return { ...state, relatedProductFeatures: action.payload };
 }
 
 const relatedSlice = createSlice({
@@ -32,7 +32,7 @@ const relatedSlice = createSlice({
     newRelatedCarouselIndex: moveRelatedCarousel,
     newOutfitCarouselIndex: moveOutfitCarousel,
     newModalState: toggleModal,
-    newCurrentRelatedProduct: setCurrentRelatedProduct,
+    newRelatedProductFeatures: setRelatedProductFeatures,
   },
   extraReducers: (builder) => {
     builder
@@ -47,7 +47,7 @@ export const {
   newRelatedCarouselIndex,
   newOutfitCarouselIndex,
   newModalState,
-  newCurrentRelatedProduct,
+  newRelatedProductFeatures,
 } = relatedSlice.actions;
 
 export default relatedSlice.reducer;

--- a/client/src/features/reviews/reviewsSlice.js
+++ b/client/src/features/reviews/reviewsSlice.js
@@ -4,7 +4,6 @@ import { api } from '../api/apiSlice';
 const initialState = {
   reviews: {},
   meta: {},
-  refFn: {},
 };
 
 function updateState(state = initialState, action) {


### PR DESCRIPTION
All commits involve generating the comparison modal data.
The modal is currently visible as a standalone element and changes when the user clicks on the related product and then the 'comparing' text element.